### PR TITLE
Revised Issue 1, moved types in to particle_core namespace

### DIFF
--- a/cores/esp8266/OakParticle/Oak.cpp
+++ b/cores/esp8266/OakParticle/Oak.cpp
@@ -2,7 +2,14 @@
 #include "Oak.h"
 #include "particle_core.h"
 
-void OakClass::rebootToUser(void) { rebootToUser(); }
-void OakClass::rebootToConfig(void) { rebootToConfig(); }
+using namespace ParticleCore;
+
+
+void OakClass::rebootToUser(void) { 
+	rebootToUser(); 
+}
+void OakClass::rebootToConfig(void) { 
+	rebootToConfig(); 
+}
 
 OakClass Oak;

--- a/cores/esp8266/OakParticle/Oak.cpp
+++ b/cores/esp8266/OakParticle/Oak.cpp
@@ -2,7 +2,7 @@
 #include "Oak.h"
 #include "particle_core.h"
 
-using namespace ParticleCore;
+using namespace particle_core;
 
 
 void OakClass::rebootToUser(void) { 

--- a/cores/esp8266/OakParticle/OakParticle.cpp
+++ b/cores/esp8266/OakParticle/OakParticle.cpp
@@ -2,6 +2,9 @@
 #include "particle_core.h"
 #include "OakParticle.h"
 
+using namespace ParticleCore;
+
+
 CloudClass::CloudClass(){
     spark_initConfig();
 }

--- a/cores/esp8266/OakParticle/OakParticle.cpp
+++ b/cores/esp8266/OakParticle/OakParticle.cpp
@@ -2,7 +2,7 @@
 #include "particle_core.h"
 #include "OakParticle.h"
 
-using namespace ParticleCore;
+using namespace particle_core;
 
 
 CloudClass::CloudClass(){

--- a/cores/esp8266/OakParticle/OakParticle.h
+++ b/cores/esp8266/OakParticle/OakParticle.h
@@ -39,85 +39,85 @@ public:
 
     static inline bool variable(const char* varKey, const int& var)
     {
-        return variable(varKey, &var, ParticleCore::INT);
+        return variable(varKey, &var, particle_core::INT);
     }
     static inline bool variable(const char* varKey, const uint32_t& var)
     {
-        return variable(varKey, &var, ParticleCore::INT);
+        return variable(varKey, &var, particle_core::INT);
     }
 
     static inline bool variable(const char* varKey, const double& var)
     {
-        return variable(varKey, &var, ParticleCore::DOUBLE);
+        return variable(varKey, &var, particle_core::DOUBLE);
     }
 
     static inline bool variable(const char* varKey, const String& var)
     {
-        return variable(varKey, &var, ParticleCore::STRING);
+        return variable(varKey, &var, particle_core::STRING);
     }
 
     static inline bool variable(const char* varKey, const char* var)
     {
-        return variable(varKey, var, ParticleCore::STRING);
+        return variable(varKey, var, particle_core::STRING);
     }
 
     template<std::size_t N>
     static inline bool variable(const char* varKey, const char var[N])
     {
-        return variable(varKey, var, ParticleCore::STRING);
+        return variable(varKey, var, particle_core::STRING);
     }
 
     template<std::size_t N>
     static inline bool variable(const char* varKey, const unsigned char var[N])
     {
-        return variable(varKey, var, ParticleCore::STRING);
+        return variable(varKey, var, particle_core::STRING);
     }
 
-    static inline bool variable(const char *varKey, const uint8_t* userVar, const ParticleCore::CloudVariableTypeString& userVarType)
+    static inline bool variable(const char *varKey, const uint8_t* userVar, const particle_core::CloudVariableTypeString& userVarType)
     {
         return variable(varKey, (const char*)userVar, userVarType);
     }
 
     template<typename T> static bool variable(const char *varKey, const typename T::varref userVar, const T& userVarType);
 
-    static bool variable(const char *varKey, const int32_t* userVar, const ParticleCore::CloudVariableTypeInt& userVarType);
-    static bool variable(const char *varKey, const uint32_t* userVar, const ParticleCore::CloudVariableTypeInt& userVarType);
+    static bool variable(const char *varKey, const int32_t* userVar, const particle_core::CloudVariableTypeInt& userVarType);
+    static bool variable(const char *varKey, const uint32_t* userVar, const particle_core::CloudVariableTypeInt& userVarType);
 
     // Return clear errors for common misuses of Particle.variable()
     template<typename T, std::size_t N>
-    static inline bool variable(const char *varKey, const T (*userVar)[N], const ParticleCore::CloudVariableTypeString& userVarType)
+    static inline bool variable(const char *varKey, const T (*userVar)[N], const particle_core::CloudVariableTypeString& userVarType)
     {
         static_assert(sizeof(T)==0, "\n\nUse Particle.variable(\"name\", myVar, STRING); without & in front of myVar\n\n");
         return false;
     }
 
     template<typename T>
-    static bool variable(const T *varKey, const String *userVar, const ParticleCore::CloudVariableTypeString& userVarType);
+    static bool variable(const T *varKey, const String *userVar, const particle_core::CloudVariableTypeString& userVarType);
 
     template<typename T>
-    static inline bool variable(const T *varKey, const String &userVar, const ParticleCore::CloudVariableTypeString& userVarType)
+    static inline bool variable(const T *varKey, const String &userVar, const particle_core::CloudVariableTypeString& userVarType)
     {
         static_assert(sizeof(T)==0, "\n\nIn Particle.variable(\"name\", myVar, STRING); myVar must be declared as char myVar[] not String myVar\n\n");
         return false;
     }
 
-    static bool function(const char *funcKey, ParticleCore::user_function_int_str_t* func);
-    static bool function(const char *funcKey, ParticleCore::user_std_function_int_str_t func, void* reserved=NULL);
+    static bool function(const char *funcKey, particle_core::user_function_int_str_t* func);
+    static bool function(const char *funcKey, particle_core::user_std_function_int_str_t func, void* reserved=NULL);
 
     template <typename T>
     static void function(const char *funcKey, int (T::*func)(String), T *instance);
 
-    bool publish(const char *eventName, ParticleCore::Spark_Event_TypeDef eventType=ParticleCore::PUBLIC);
-    bool publish(const char *eventName, const char *eventData, ParticleCore::Spark_Event_TypeDef eventType=ParticleCore::PUBLIC);
-    bool publish(const char *eventName, const char *eventData, int ttl, ParticleCore::Spark_Event_TypeDef eventType=ParticleCore::PUBLIC);
+    bool publish(const char *eventName, particle_core::Spark_Event_TypeDef eventType=particle_core::PUBLIC);
+    bool publish(const char *eventName, const char *eventData, particle_core::Spark_Event_TypeDef eventType=particle_core::PUBLIC);
+    bool publish(const char *eventName, const char *eventData, int ttl, particle_core::Spark_Event_TypeDef eventType=particle_core::PUBLIC);
 
-    bool subscribe(const char *eventName, EventHandler handler, ParticleCore::Spark_Subscription_Scope_TypeDef scope=ParticleCore::ALL_DEVICES);
+    bool subscribe(const char *eventName, EventHandler handler, particle_core::Spark_Subscription_Scope_TypeDef scope=particle_core::ALL_DEVICES);
     bool subscribe(const char *eventName, EventHandler handler, const char *deviceID);
-    bool subscribe(const char *eventName, ParticleCore::wiring_event_handler_t handler, ParticleCore::Spark_Subscription_Scope_TypeDef scope=ParticleCore::ALL_DEVICES);
-    bool subscribe(const char *eventName, ParticleCore::wiring_event_handler_t handler, const char *deviceID);
+    bool subscribe(const char *eventName, particle_core::wiring_event_handler_t handler, particle_core::Spark_Subscription_Scope_TypeDef scope=particle_core::ALL_DEVICES);
+    bool subscribe(const char *eventName, particle_core::wiring_event_handler_t handler, const char *deviceID);
 
     template <typename T>
-    bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, ParticleCore::Spark_Subscription_Scope_TypeDef scope=ParticleCore::ALL_DEVICES);
+    bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, particle_core::Spark_Subscription_Scope_TypeDef scope=particle_core::ALL_DEVICES);
     template <typename T>
     bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, const char *deviceID);
 
@@ -148,9 +148,9 @@ private:
 
     //static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    bool subscribe_wiring(const char *eventName, ParticleCore::wiring_event_handler_t handler, ParticleCore::Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL);
+    bool subscribe_wiring(const char *eventName, particle_core::wiring_event_handler_t handler, particle_core::Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL);
 
-    static const void* update_string_variable(const char* name, ParticleCore::Spark_Data_TypeDef type, const void* var, void* reserved);
+    static const void* update_string_variable(const char* name, particle_core::Spark_Data_TypeDef type, const void* var, void* reserved);
 };
 
 extern CloudClass Particle;

--- a/cores/esp8266/OakParticle/OakParticle.h
+++ b/cores/esp8266/OakParticle/OakParticle.h
@@ -39,85 +39,85 @@ public:
 
     static inline bool variable(const char* varKey, const int& var)
     {
-        return variable(varKey, &var, INT);
+        return variable(varKey, &var, ParticleCore::INT);
     }
     static inline bool variable(const char* varKey, const uint32_t& var)
     {
-        return variable(varKey, &var, INT);
+        return variable(varKey, &var, ParticleCore::INT);
     }
 
     static inline bool variable(const char* varKey, const double& var)
     {
-        return variable(varKey, &var, DOUBLE);
+        return variable(varKey, &var, ParticleCore::DOUBLE);
     }
 
     static inline bool variable(const char* varKey, const String& var)
     {
-        return variable(varKey, &var, STRING);
+        return variable(varKey, &var, ParticleCore::STRING);
     }
 
     static inline bool variable(const char* varKey, const char* var)
     {
-        return variable(varKey, var, STRING);
+        return variable(varKey, var, ParticleCore::STRING);
     }
 
     template<std::size_t N>
     static inline bool variable(const char* varKey, const char var[N])
     {
-        return variable(varKey, var, STRING);
+        return variable(varKey, var, ParticleCore::STRING);
     }
 
     template<std::size_t N>
     static inline bool variable(const char* varKey, const unsigned char var[N])
     {
-        return variable(varKey, var, STRING);
+        return variable(varKey, var, ParticleCore::STRING);
     }
 
-    static inline bool variable(const char *varKey, const uint8_t* userVar, const CloudVariableTypeString& userVarType)
+    static inline bool variable(const char *varKey, const uint8_t* userVar, const ParticleCore::CloudVariableTypeString& userVarType)
     {
         return variable(varKey, (const char*)userVar, userVarType);
     }
 
     template<typename T> static bool variable(const char *varKey, const typename T::varref userVar, const T& userVarType);
 
-    static bool variable(const char *varKey, const int32_t* userVar, const CloudVariableTypeInt& userVarType);
-    static bool variable(const char *varKey, const uint32_t* userVar, const CloudVariableTypeInt& userVarType);
+    static bool variable(const char *varKey, const int32_t* userVar, const ParticleCore::CloudVariableTypeInt& userVarType);
+    static bool variable(const char *varKey, const uint32_t* userVar, const ParticleCore::CloudVariableTypeInt& userVarType);
 
     // Return clear errors for common misuses of Particle.variable()
     template<typename T, std::size_t N>
-    static inline bool variable(const char *varKey, const T (*userVar)[N], const CloudVariableTypeString& userVarType)
+    static inline bool variable(const char *varKey, const T (*userVar)[N], const ParticleCore::CloudVariableTypeString& userVarType)
     {
         static_assert(sizeof(T)==0, "\n\nUse Particle.variable(\"name\", myVar, STRING); without & in front of myVar\n\n");
         return false;
     }
 
     template<typename T>
-    static bool variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType);
+    static bool variable(const T *varKey, const String *userVar, const ParticleCore::CloudVariableTypeString& userVarType);
 
     template<typename T>
-    static inline bool variable(const T *varKey, const String &userVar, const CloudVariableTypeString& userVarType)
+    static inline bool variable(const T *varKey, const String &userVar, const ParticleCore::CloudVariableTypeString& userVarType)
     {
         static_assert(sizeof(T)==0, "\n\nIn Particle.variable(\"name\", myVar, STRING); myVar must be declared as char myVar[] not String myVar\n\n");
         return false;
     }
 
-    static bool function(const char *funcKey, user_function_int_str_t* func);
-    static bool function(const char *funcKey, user_std_function_int_str_t func, void* reserved=NULL);
+    static bool function(const char *funcKey, ParticleCore::user_function_int_str_t* func);
+    static bool function(const char *funcKey, ParticleCore::user_std_function_int_str_t func, void* reserved=NULL);
 
     template <typename T>
     static void function(const char *funcKey, int (T::*func)(String), T *instance);
 
-    bool publish(const char *eventName, Spark_Event_TypeDef eventType=PUBLIC);
-    bool publish(const char *eventName, const char *eventData, Spark_Event_TypeDef eventType=PUBLIC);
-    bool publish(const char *eventName, const char *eventData, int ttl, Spark_Event_TypeDef eventType=PUBLIC);
+    bool publish(const char *eventName, ParticleCore::Spark_Event_TypeDef eventType=ParticleCore::PUBLIC);
+    bool publish(const char *eventName, const char *eventData, ParticleCore::Spark_Event_TypeDef eventType=ParticleCore::PUBLIC);
+    bool publish(const char *eventName, const char *eventData, int ttl, ParticleCore::Spark_Event_TypeDef eventType=ParticleCore::PUBLIC);
 
-    bool subscribe(const char *eventName, EventHandler handler, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES);
+    bool subscribe(const char *eventName, EventHandler handler, ParticleCore::Spark_Subscription_Scope_TypeDef scope=ParticleCore::ALL_DEVICES);
     bool subscribe(const char *eventName, EventHandler handler, const char *deviceID);
-    bool subscribe(const char *eventName, wiring_event_handler_t handler, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES);
-    bool subscribe(const char *eventName, wiring_event_handler_t handler, const char *deviceID);
+    bool subscribe(const char *eventName, ParticleCore::wiring_event_handler_t handler, ParticleCore::Spark_Subscription_Scope_TypeDef scope=ParticleCore::ALL_DEVICES);
+    bool subscribe(const char *eventName, ParticleCore::wiring_event_handler_t handler, const char *deviceID);
 
     template <typename T>
-    bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES);
+    bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, ParticleCore::Spark_Subscription_Scope_TypeDef scope=ParticleCore::ALL_DEVICES);
     template <typename T>
     bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, const char *deviceID);
 
@@ -148,9 +148,9 @@ private:
 
     //static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    bool subscribe_wiring(const char *eventName, wiring_event_handler_t handler, Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL);
+    bool subscribe_wiring(const char *eventName, ParticleCore::wiring_event_handler_t handler, ParticleCore::Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL);
 
-    static const void* update_string_variable(const char* name, Spark_Data_TypeDef type, const void* var, void* reserved);
+    static const void* update_string_variable(const char* name, ParticleCore::Spark_Data_TypeDef type, const void* var, void* reserved);
 };
 
 extern CloudClass Particle;

--- a/cores/esp8266/OakParticle/particle.h
+++ b/cores/esp8266/OakParticle/particle.h
@@ -10,7 +10,7 @@
 #define OAK_SYSTEM_VERSION 1
 extern char OAK_SYSTEM_VERSION_STRING[];
 
-namespace ParticleCore {
+namespace particle_core {
 
 typedef int (user_function_int_str_t)(String paramString);
 typedef user_function_int_str_t* p_user_function_int_str_t;
@@ -99,6 +99,6 @@ namespace SparkReturnType {
   };
 }
 
-}; // ParticleCore
+}; // particle_core
 
 #endif // particle_h

--- a/cores/esp8266/OakParticle/particle.h
+++ b/cores/esp8266/OakParticle/particle.h
@@ -10,6 +10,7 @@
 #define OAK_SYSTEM_VERSION 1
 extern char OAK_SYSTEM_VERSION_STRING[];
 
+namespace ParticleCore {
 
 typedef int (user_function_int_str_t)(String paramString);
 typedef user_function_int_str_t* p_user_function_int_str_t;
@@ -88,7 +89,6 @@ extern const CloudVariableTypeInt INT;
 extern const CloudVariableTypeString STRING;
 extern const CloudVariableTypeDouble DOUBLE;
 
-
 // Deferring to ASN.1 type codes
 namespace SparkReturnType {
   enum Enum {
@@ -99,5 +99,6 @@ namespace SparkReturnType {
   };
 }
 
+}; // ParticleCore
 
 #endif // particle_h

--- a/cores/esp8266/OakParticle/particle_core.cpp
+++ b/cores/esp8266/OakParticle/particle_core.cpp
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 
-namespace ParticleCore {
+namespace particle_core {
 
 #define PROTOCOL_BUFFER_SIZE 800
 #define QUEUE_SIZE 800
@@ -2627,4 +2627,4 @@ void spark_process()
 }
 
 
-}; // ParticleCore
+}; // particle_core

--- a/cores/esp8266/OakParticle/particle_core.cpp
+++ b/cores/esp8266/OakParticle/particle_core.cpp
@@ -1,12 +1,6 @@
 #include "particle_core.h"
 
 char OAK_SYSTEM_VERSION_STRING[5] = {"1.00"};
-#define PROTOCOL_BUFFER_SIZE 800
-#define QUEUE_SIZE 800
-unsigned char queue[PROTOCOL_BUFFER_SIZE];
-
-typedef unsigned short uint16_t;
-typedef uint16_t chunk_index_t;
 
 //#include <Arduino.h>
 #include "../ESP8266WiFi/src/ESP8266WiFi.h"
@@ -20,8 +14,6 @@ typedef uint16_t chunk_index_t;
 #include "appender.h"
 #include "file_transfer.h"
 #include "crc32.h"
-
-WiFiClient pClient; 
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,7 +29,19 @@ extern "C" {
 #endif
 
 
- typedef struct {
+namespace ParticleCore {
+
+#define PROTOCOL_BUFFER_SIZE 800
+#define QUEUE_SIZE 800
+
+WiFiClient pClient; 
+
+typedef unsigned short uint16_t;
+typedef uint16_t chunk_index_t;
+
+unsigned char queue[PROTOCOL_BUFFER_SIZE];
+
+typedef struct {
   //can cut off here if needed
   char device_id[25];     //device id in hex
   char claim_code[65];   // server public key
@@ -2623,4 +2627,4 @@ void spark_process()
 }
 
 
-
+}; // ParticleCore

--- a/cores/esp8266/OakParticle/particle_core.h
+++ b/cores/esp8266/OakParticle/particle_core.h
@@ -3,6 +3,8 @@
 
 #include "particle.h"
 
+namespace ParticleCore {
+	
 typedef std::function<bool(const void*, SparkReturnType::Enum)> FunctionResultCallback;
 
 int call_raw_user_function(void* data, const char* param, void* reserved);
@@ -215,5 +217,6 @@ bool spark_connect();
 
 void spark_process();
 
+}; // ParticleCore
 
 #endif // particle_core_h

--- a/cores/esp8266/OakParticle/particle_core.h
+++ b/cores/esp8266/OakParticle/particle_core.h
@@ -3,7 +3,7 @@
 
 #include "particle.h"
 
-namespace ParticleCore {
+namespace particle_core {
 	
 typedef std::function<bool(const void*, SparkReturnType::Enum)> FunctionResultCallback;
 
@@ -217,6 +217,6 @@ bool spark_connect();
 
 void spark_process();
 
-}; // ParticleCore
+}; // particle_core
 
 #endif // particle_core_h


### PR DESCRIPTION
https://github.com/digistump/OakCore/issues/1

I went ahead and closed https://github.com/digistump/OakCore/pull/4 as I think this is better.

This wraps all the internals in a namespace `particle_core`, so they will no longer pollute the global namespace.

After thinking about it, all the internal code tends to use `underscore_syntax`, where publicly accessible interfaces use `StudlyCaps`, so instead of using the namespace `ParticleCore`, it now uses `particle_core`.
