### PR TITLE
Missing #define for OneWire

### DIFF
--- a/variants/oak/pins_arduino.h
+++ b/variants/oak/pins_arduino.h
@@ -27,6 +27,8 @@
 #ifndef Pins_Arduino_h
 #define Pins_Arduino_h
 
+/*Required for onewire library*/
+#define ARDUINO_ARCH_ESP8266 1 
 
 #define EXTERNAL_NUM_INTERRUPTS 10
 #define NUM_DIGITAL_PINS        11


### PR DESCRIPTION
Fixes issue #22 
Just added the define.
