### PR TITLE
Cloud serial fixes

### DIFF
--- a/cores/oak/OakParticle/particle_core.cpp
+++ b/cores/oak/OakParticle/particle_core.cpp
@@ -3110,6 +3110,10 @@ void spark_serial_end()
 // Read data from buffer
 int spark_serial_read()
 {
+    // Return if cloud serial not initialized
+    if (spark_serial_state < 2)
+        return -1;
+
     // Empty buffer?
     if (spark_receive_buffer_head == spark_receive_buffer_tail)
         return -1;
@@ -3127,6 +3131,10 @@ int spark_serial_available()
 
 size_t spark_serial_write(uint8_t b)
 {
+    // Return if cloud serial not initialized
+    if (spark_serial_state < 2)
+        return -1;
+
     // if buffer full, set the overflow flag and return
     uint8_t next = (spark_transmit_buffer_tail + 1) % MAX_SERIAL_BUFF;
     if (next != spark_transmit_buffer_head)
@@ -3150,6 +3158,10 @@ void spark_serial_flush()
 
 int spark_serial_peek()
 {
+    // Return if cloud serial not initialized
+    if (spark_serial_state < 2)
+        return -1;
+
     // Empty buffer?
     if (spark_receive_buffer_head == spark_receive_buffer_tail)
         return -1;

--- a/cores/oak/OakParticle/particle_core.h
+++ b/cores/oak/OakParticle/particle_core.h
@@ -248,7 +248,7 @@ size_t spark_serial_write(uint8_t b);
 void spark_serial_flush();
 int spark_serial_peek();
 void spark_get_rx(const char* name, const char* data);
-void spark_send_tx();
+int spark_send_tx();
 void spark_process(bool internal = false,bool allow_connect = true);
 
 String info_response(void);


### PR DESCRIPTION
- Adds rate limiting for cloud serial events
- Checks cloud serial is initialized before use to guard against a fatal exception
- Fixes a buffer overflow
- Improves read and write buffer indexing and utilization
