### PR TITLE
Enable cloud serial comms to individual devices

### DIFF
--- a/cores/oak/OakParticle/particle_core.cpp
+++ b/cores/oak/OakParticle/particle_core.cpp
@@ -2792,6 +2792,9 @@ const char* RESET_EVENT = "spark/device/reset";
 const char* OAK_RESET_EVENT = "oak/device/reset";
 const char* OAK_RX_EVENT = "oak/device/stdin";
 
+#define OAK_RESET_EVENT_LEN 16
+#define OAK_RX_EVENT_LEN    16
+
 void SystemEvents(const char* name, const char* data)
 {
     if (!strncmp(name, CLAIM_EVENTS, strlen(CLAIM_EVENTS))) {
@@ -2810,7 +2813,10 @@ void SystemEvents(const char* name, const char* data)
                 ESP.reset();
         }
     }
-    if (!strcmp(name, OAK_RESET_EVENT)) {
+    if (!strncmp(name, OAK_RESET_EVENT, OAK_RESET_EVENT_LEN) &&
+        (name[OAK_RESET_EVENT_LEN] == 0 ||
+        (name[OAK_RESET_EVENT_LEN] == '/' &&
+        !strcmp((name+OAK_RESET_EVENT_LEN+1),deviceConfig->device_id)))) {
         if (data && *data) {
             if (!strcmp("config mode", data))
                 reboot_to_config();
@@ -3180,7 +3186,11 @@ void spark_get_rx(const char* name, const char* data){ //this is automatically c
   if(spark_serial_state < 2){
     return;
   }
-
+    if ((name[OAK_RX_EVENT_LEN] != 0 &&
+        (name[OAK_RX_EVENT_LEN] != '/' ||
+        strcmp((name+OAK_RX_EVENT_LEN+1),deviceConfig->device_id)))) {
+        return;
+    }
     if (data && *data) {
 
         while(*data != '\0'){


### PR DESCRIPTION
I've implemented the workaround discussed in #30, as described below. With a corresponding change to OakTerm, this works correctly for my Oaks. You can test this modified OakTerm here: https://rawgit.com/kh90909/OakTerm/send-to-specific-devices/index.html. It's still in a feature branch for now, but hope to merge it into master tomorrow, along with lots more progress by @emcniece and myself.

---
#### Commit message

The Particle Cloud API and ParticleJS do not appear to allow publishing events to specific devices. This change works around that limitation by having the Oaks listen to `/oak/device/stdin/:deviceid` and `/oak/device/reset/:deviceid` so that they can be individually addressed.

The Oaks are also still listening to `/oak/device/stdin` and `/oak/device/reset` so that all of one's Oaks can be addressed simultaneously if desired.
