### PR TITLE
Allow the current mode to be queried

### DIFF
--- a/cores/oak/OakParticle/particle_core.cpp
+++ b/cores/oak/OakParticle/particle_core.cpp
@@ -2826,6 +2826,13 @@ void SystemEvents(const char* name, const char* data)
                 reboot_to_fallback_updater();
             else if (!strcmp("reboot", data))
                 ESP.reset();
+            else if (!strcmp("mode?",data))
+                if (bootConfig->current_rom == bootConfig->config_rom)
+                    spark_send_event("oak/device/mode/config", "", 60, PRIVATE, NULL);
+                else if (bootConfig->current_rom == bootConfig->program_rom)
+                    spark_send_event("oak/device/mode/user", "", 60, PRIVATE, NULL);
+                else if (bootConfig->current_rom == bootConfig->update_rom)
+                    spark_send_event("oak/device/mode/update", "", 60, PRIVATE, NULL);
         }
     }
     if (!strcmp(name, OAK_RX_EVENT)) {


### PR DESCRIPTION
@digistump how would you feel about adding the ability to query the mode (config/user/update) an Oak is in, using the method in this pull request or similar? This would allow us to query and display the current mode in OakTerm.

If so, is this the correct logic to determine the current mode, or are there special cases that need to be accounted for?
