### PR TITLE
Restore blink during OTA update

### DIFF
--- a/cores/oak/OakParticle/particle_core.cpp
+++ b/cores/oak/OakParticle/particle_core.cpp
@@ -2408,10 +2408,11 @@ bool event_loop()
   {
     CoAPMessageType::Enum message;
     bool res;
+    uint32_t start = millis();
     do {
       res = event_loop(message);
       yield();
-    }while(res && pClient.available() >= 2);
+    }while(res && pClient.available() >= 2 && (millis()-start) < 20);
 
     return res;
   }


### PR DESCRIPTION
The previous change to event_loop() to process all events accumulated
in the buffer, rather than one per call, had inadvertently prevented
the OTA update blink. During the OTA update, data comes in fast enough
that the buffer never empties, so the first call to event_loop() doesn't
finish until the update is done. As a result, the blink loop at the end
of handle_update_begin() only runs for one iteration.

This commit adds a 20 ms time limit after which event_loop() will stop
processing further events and return.
