### PR TITLE
Added LED_BUILTIN to all three variant types

### DIFF
--- a/libraries/DNSServer/library.properties
+++ b/libraries/DNSServer/library.properties
@@ -6,4 +6,4 @@ sentence=A simple DNS server for ESP8266.
 paragraph=This library implements a simple DNS server.
 category=Communication
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/Dummy/library.properties
+++ b/libraries/Dummy/library.properties
@@ -6,4 +6,4 @@ sentence=Just a library which does nothing
 paragraph=
 category=Other
 url=http://localhost
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -6,4 +6,4 @@ sentence=Enables reading and writing data to the permanent FLASH storage, up to 
 paragraph=
 category=Data Storage
 url=http://arduino.cc/en/Reference/EEPROM
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/ESP8266AVRISP/library.properties
+++ b/libraries/ESP8266AVRISP/library.properties
@@ -6,4 +6,4 @@ sentence=AVR In-System Programming over WiFi for ESP8266
 paragraph=This library allows programming 8-bit AVR ICSP targets via TCP over WiFi with ESP8266.
 category=Communication
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/ESP8266HTTPClient/library.properties
+++ b/libraries/ESP8266HTTPClient/library.properties
@@ -6,4 +6,4 @@ sentence=http Client for ESP8266
 paragraph=
 category=Communication
 url=https://github.com/Links2004/Arduino/tree/libraries/ESP8266HTTPClient
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/ESP8266WebServer/library.properties
+++ b/libraries/ESP8266WebServer/library.properties
@@ -6,4 +6,4 @@ sentence=Simple web server library
 paragraph=The library supports HTTP GET and POST requests, provides argument parsing, handles one client at a time.
 category=Communication
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/ESP8266WiFi/library.properties
+++ b/libraries/ESP8266WiFi/library.properties
@@ -6,4 +6,4 @@ sentence=Enables network connection (local and Internet) using the ESP8266 built
 paragraph=With this library you can instantiate Servers, Clients and send/receive UDP packets through WiFi. The shield can connect either to open or encrypted networks (WEP, WPA). The IP address can be assigned statically or through a DHCP. The library can also manage DNS.
 category=Communication
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/ESP8266WiFiMesh/library.properties
+++ b/libraries/ESP8266WiFiMesh/library.properties
@@ -6,4 +6,4 @@ sentence=Mesh network library
 paragraph=The library sets up a Mesh Node which acts as a router, creating a Mesh Network with other nodes.
 category=Communication
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/GDBStub/library.properties
+++ b/libraries/GDBStub/library.properties
@@ -6,4 +6,4 @@ sentence=GDB server stub from Cesanta's Smart.js
 paragraph=GDB server stub helps debug crashes when JTAG isn't an option.
 category=Uncategorized
 url=https://github.com/cesanta/smart.js
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/Hash/library.properties
+++ b/libraries/Hash/library.properties
@@ -6,4 +6,4 @@ sentence=Generate Hash from data
 paragraph=
 category=Data Processing
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -6,4 +6,4 @@ sentence=Enables the communication with devices that use the Serial Peripheral I
 paragraph=
 category=Signal Input/Output
 url=http://arduino.cc/en/Reference/SPI
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -6,4 +6,4 @@ sentence=Allows Esp8266 boards to control a variety of servo motors.
 paragraph=This library can control a great number of servos.<br />It makes careful use of timers: the library can control 12 servos using only 1 timer.<br />
 category=Device Control
 url=http://arduino.cc/en/Reference/Servo
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/SoftwareSerial/library.properties
+++ b/libraries/SoftwareSerial/library.properties
@@ -6,4 +6,4 @@ sentence=Implementation of the Arduino software serial for ESP8266.
 paragraph=
 category=Signal Input/Output
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/Ticker/library.properties
+++ b/libraries/Ticker/library.properties
@@ -6,4 +6,4 @@ sentence=Allows to call functions with a given interval.
 paragraph=
 category=Timing
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -6,4 +6,4 @@ sentence=Allows the communication between devices or sensors connected via Two W
 paragraph=
 category=Signal Input/Output
 url=http://arduino.cc/en/Reference/Wire
-architectures=esp8266
+architectures=esp8266,oak

--- a/libraries/esp8266/library.properties
+++ b/libraries/esp8266/library.properties
@@ -6,4 +6,4 @@ sentence=ESP8266 sketches examples
 paragraph=
 category=Other
 url=
-architectures=esp8266
+architectures=esp8266,oak

--- a/variants/oak/pins_arduino.h
+++ b/variants/oak/pins_arduino.h
@@ -52,6 +52,7 @@ static const uint8_t MISO  = 8;
 static const uint8_t SCK   = 9;
 
 static const uint8_t BUILTIN_LED = 1;
+static const uint8_t LED_BUILTIN = 1;
 
 static const uint8_t A0 = 17;
                               ///0, 1, 2, 3, 4, 5, 6,  7,  8,  9,  10, 11

--- a/variants/oak1/pins_arduino.h
+++ b/variants/oak1/pins_arduino.h
@@ -54,6 +54,7 @@ static const uint8_t MISO  = 8;
 static const uint8_t SCK   = 9;
 
 static const uint8_t BUILTIN_LED = 1;
+static const uint8_t LED_BUILTIN = 1;
 
 static const uint8_t A0 = 17;
                               ///0, 1, 2, 3, 4, 5, 6,  7,  8,  9,  10, 11

--- a/variants/oak1_noauto/pins_arduino.h
+++ b/variants/oak1_noauto/pins_arduino.h
@@ -55,6 +55,7 @@ static const uint8_t MISO  = 8;
 static const uint8_t SCK   = 9;
 
 static const uint8_t BUILTIN_LED = 1;
+static const uint8_t LED_BUILTIN = 1;
 
 static const uint8_t A0 = 17;
                               ///0, 1, 2, 3, 4, 5, 6,  7,  8,  9,  10, 11


### PR DESCRIPTION
The [Arduino reference documentation](https://www.arduino.cc/en/Reference/Constants) (last heading at the time of writing) indicates that the built-in led constant should be LED_BUILTIN, not BUILTIN_LED. Best compromise to prevent breaking any existing code is to define both forms.
