### PR TITLE
Fix endian inversion in SPI transfer16 and tone() crashes

### DIFF
--- a/cores/oak/Tone.cpp
+++ b/cores/oak/Tone.cpp
@@ -82,7 +82,12 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
         timer1_isr_init();
         timer1_attachInterrupt(t1IntHandler);
         timer1_enable(TIM_DIV1, TIM_EDGE, TIM_LOOP);
-        timer1_write((clockCyclesPerMicrosecond() * 500000) / frequency);
+        if (frequency == 0) {
+          timer1_write((clockCyclesPerMicrosecond() * 500000));
+        }
+        else {
+          timer1_write((clockCyclesPerMicrosecond() * 500000) / frequency);
+        }
         break;
     }
   }

--- a/cores/oak/Tone.cpp
+++ b/cores/oak/Tone.cpp
@@ -33,7 +33,6 @@ static long toggle_counts[AVAILABLE_TONE_PINS] = { 0, };
 void t1IntHandler();
 
 static int8_t toneBegin(uint8_t _pin) {
-  _pin = esp8266_pinToGpio[_pin];
   int8_t _index = -1;
 
   // if we're already using the pin, reuse it.
@@ -57,7 +56,6 @@ static int8_t toneBegin(uint8_t _pin) {
 
 // frequency (in hertz) and duration (in milliseconds).
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
-  _pin = esp8266_pinToGpio[_pin];
   int8_t _index;
 
   _index = toneBegin(_pin);
@@ -105,7 +103,6 @@ void disableTimer(uint8_t _index) {
 }
 
 void noTone(uint8_t _pin) {
-  _pin = esp8266_pinToGpio[_pin];
   for (int i = 0; i < AVAILABLE_TONE_PINS; i++) {
     if (tone_pins[i] == _pin) {
       tone_pins[i] = 255;

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -243,13 +243,13 @@ uint16_t SPIClass::transfer16(uint16_t data) {
     in.val = data;
 
     if((SPI1C & (SPICWBO | SPICRBO))) {
-        //MSBFIRST
-        out.msb = transfer(in.msb);
-        out.lsb = transfer(in.lsb);
+      //LSBFIRST
+       out.lsb = transfer(in.lsb);
+       out.msb = transfer(in.msb);
     } else {
-        //LSBFIRST
-        out.lsb = transfer(in.lsb);
-        out.msb = transfer(in.msb);
+       //MSBFIRST
+       out.msb = transfer(in.msb);
+       out.lsb = transfer(in.lsb);
     }
     return out.val;
 }
@@ -451,4 +451,3 @@ void SPIClass::transferBytes_(uint8_t * out, uint8_t * in, uint8_t size) {
         }
     }
 }
-


### PR DESCRIPTION
Ported from esp8266/Arduino@bda2125 as was raised on the Oak forum @ http://digistump.com/board/index.php/topic,2494.0.html.