### PR TITLE
Template for the String datatype for Particle Variable was not being used

### DIFF
--- a/cores/oak/OakParticle/OakParticle.cpp
+++ b/cores/oak/OakParticle/OakParticle.cpp
@@ -7,14 +7,6 @@ using namespace particle_core;
 CloudClass::CloudClass(){
     spark_initConfig(false);
 }
-template<typename T>
-bool CloudClass::variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType)
-{
-    spark_variable_t extra;
-    extra.size = sizeof(extra);
-    extra.update = update_string_variable;
-    return CLOUD_FN(spark_variable(varKey, userVar, CloudVariableTypeString::value(), &extra), false);
-}
 
 bool CloudClass::function(const char *funcKey, user_function_int_str_t* func)
 {

--- a/cores/oak/OakParticle/OakParticle.h
+++ b/cores/oak/OakParticle/OakParticle.h
@@ -118,7 +118,13 @@ public:
     }
 
     template<typename T>
-    static bool variable(const T *varKey, const String *userVar, const particle_core::CloudVariableTypeString& userVarType);
+    static inline bool variable(const T *varKey, const String *userVar, const particle_core::CloudVariableTypeString& userVarType)
+    {
+        particle_core::spark_variable_t extra;
+        extra.size = sizeof(extra);
+        extra.update = update_string_variable;
+        return CLOUD_FN(spark_variable(varKey, userVar, particle_core::CloudVariableTypeString::value(), &extra), false);
+    }
 
     template<typename T>
     static inline bool variable(const T *varKey, const String &userVar, const particle_core::CloudVariableTypeString& userVarType)


### PR DESCRIPTION
Moved and 'fixed up' the template for the String Partice Variable to OakParticle.h. It looks like it was missed when DarkLotus did his changes in https://github.com/digistump/OakCore/pull/37. Test code will be added as a second comment. Please stress test and review the code, as it worked for me, but my knowledge of (variadic) templates goes as far as copy, paste and mimic... I've managed  to avoid them completely till now   ;-O 