### PR TITLE
esp8266_pinToGpio not needed for tone()

### DIFF
--- a/cores/oak/Tone.cpp
+++ b/cores/oak/Tone.cpp
@@ -33,7 +33,6 @@ static long toggle_counts[AVAILABLE_TONE_PINS] = { 0, };
 void t1IntHandler();
 
 static int8_t toneBegin(uint8_t _pin) {
-  _pin = esp8266_pinToGpio[_pin];
   int8_t _index = -1;
 
   // if we're already using the pin, reuse it.
@@ -57,7 +56,6 @@ static int8_t toneBegin(uint8_t _pin) {
 
 // frequency (in hertz) and duration (in milliseconds).
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
-  _pin = esp8266_pinToGpio[_pin];
   int8_t _index;
 
   _index = toneBegin(_pin);


### PR DESCRIPTION
The '_pin = esp8266_pinToGpio[_pin];' pin remapping is not needed in the tone library - this actually broke tone support, and only worked with P3 as it remaps to GPIO3. Fixes second issue mentioned in #75.

To test, simply run the toneMelody example provided with the Arduino IDE under Examples -> 02. Digital, and change the pin used in lines 38 and 45 to your desired pin. The sketch default is 8, which will do as a test also.