### PR TITLE
Prevent tone with frequency of '0' from crashing.

### DIFF
--- a/cores/oak/Tone.cpp
+++ b/cores/oak/Tone.cpp
@@ -66,6 +66,13 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
     // Set the pinMode as OUTPUT
     pinMode(_pin, OUTPUT);
 
+    // Alternate handling of zero freqency to avoid divide by zero errors
+    if (frequency == 0)
+    {
+        noTone(_pin);
+        return;
+    }    
+
     // Calculate the toggle count
     if (duration > 0) {
       toggle_counts[_index] = 2 * frequency * duration / 1000;


### PR DESCRIPTION
When tone is called specifying a frequency of 0, the code will crash due to a divide by zero issue. Fixes #75.