### PR TITLE
Merge I2C time stretch utility from ESP8266 Community Core

### DIFF
--- a/cores/oak/twi.h
+++ b/cores/oak/twi.h
@@ -26,11 +26,19 @@
 extern "C" {
 #endif
 
+#define I2C_OK                      0
+#define I2C_SCL_HELD_LOW            1
+#define I2C_SCL_HELD_LOW_AFTER_READ 2
+#define I2C_SDA_HELD_LOW            3
+#define I2C_SDA_HELD_LOW_AFTER_INIT 4
+
 void twi_init(unsigned char sda, unsigned char scl);
 void twi_stop(void);
 void twi_setClock(unsigned int freq);
+void twi_setClockStretchLimit(uint32_t limit); // default value is 230 uS
 uint8_t twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 uint8_t twi_readFrom(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
+uint8_t twi_status();
 
 #ifdef __cplusplus
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -77,12 +77,20 @@ void TwoWire::begin(uint8_t address){
   begin();
 }
 
+uint8_t TwoWire::status(){
+	return twi_status();
+}
+
 void TwoWire::begin(int address){
   begin((uint8_t)address);
 }
 
 void TwoWire::setClock(uint32_t frequency){
   twi_setClock(frequency);
+}
+
+void TwoWire::setClockStretchLimit(uint32_t limit){
+  twi_setClockStretchLimit(limit);
 }
 
 size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop){
@@ -243,4 +251,6 @@ void TwoWire::onRequest( void (*function)(void) ){
 
 // Preinstantiate Objects //////////////////////////////////////////////////////
 
-TwoWire Wire = TwoWire();
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
+TwoWire Wire;
+#endif

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -56,11 +56,13 @@ class TwoWire : public Stream
     void begin(uint8_t);
     void begin(int);
     void setClock(uint32_t);
+    void setClockStretchLimit(uint32_t);
     void beginTransmission(uint8_t);
     void beginTransmission(int);
     uint8_t endTransmission(void);
     uint8_t endTransmission(uint8_t);
     size_t requestFrom(uint8_t address, size_t size, bool sendStop);
+	uint8_t status();
 
     uint8_t requestFrom(uint8_t, uint8_t);
     uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
@@ -83,7 +85,9 @@ class TwoWire : public Stream
     using Print::write;
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
 extern TwoWire Wire;
+#endif
 
 #endif
 


### PR DESCRIPTION
This isn't a full merge of the latest [esp8266 core](https://github.com/esp8266/Arduino), just essential pieces to implement i2c time stretch.  Tested with an Oak and three i2c devices (128x64 oled display, 16ch servo driver, and BNO055 inertial measurement unit).  The time stretch component of i2c was required for the BNO device but was missing from the latest Oak core.